### PR TITLE
Allow stdout/stderr to (optionally) be capture as well/instead

### DIFF
--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -157,7 +157,10 @@ def application(include=None, capture_output=False):
         # do have a message body, so use that if it's present, or fall
         # back to eventname/processname if it's not.
         message = event_data if len(event_data) \
-                             else '%s %s' % (headers['eventname'], event_body['processname'])
+                             else '%s %s' % (
+                                 headers['eventname'],
+                                 event_body['processname']
+                             )
 
         logger.info(message, extra=extra)
 
@@ -199,7 +202,8 @@ def main():  # pragma: no cover
     parser.add_argument(
         '-o', '--capture-output',
         action='store_true', default=False,
-        help='capture stdout/stderr output from supervisor processes in addition to events'
+        help='capture stdout/stderr output from supervisor '
+             'processes in addition to events'
     )
     args = parser.parse_args()
     if args.coverage:

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -106,7 +106,7 @@ def get_value_from_input(text):
     return values
 
 
-def application(include=None):
+def application(include=None, capture_output=False):
     """
     Main application loop.
     """
@@ -123,6 +123,10 @@ def application(include=None):
     events = ['BACKOFF', 'FATAL', 'EXITED', 'STOPPED', 'STARTING', 'RUNNING']
     events = ['PROCESS_STATE_' + state for state in events]
 
+    if capture_output:
+        outputs = ['STDOUT', 'STDERR']
+        events += ['PROCESS_LOG_' + output for output in outputs]
+
     logstash_handler = None
     if socket_type == 'udp':
         logstash_handler = logstash.UDPLogstashHandler
@@ -135,7 +139,7 @@ def application(include=None):
     logger.addHandler(logstash_handler(host, port, version=1))
     logger.setLevel(logging.INFO)
 
-    for headers, event_body, _ in supervisor_events(
+    for headers, event_body, event_data in supervisor_events(
             sys.stdin, sys.stdout, *events):
         extra = event_body.copy()
         extra['eventname'] = headers['eventname']
@@ -148,10 +152,14 @@ def application(include=None):
             if len(user_data) > 0:
                 extra['user_data'] = user_data
 
-        logger.info(
-            '%s %s', headers['eventname'], event_body['processname'],
-            extra=extra,
-        )
+        # Events, like starting/stopping don't have a message body and
+        # the data is set to '' in event_data(). Stdout/Stderr events
+        # do have a message body, so use that if it's present, or fall
+        # back to eventname/processname if it's not.
+        message = event_data if len(event_data) \
+                             else '%s %s' % (headers['eventname'], event_body['processname'])
+
+        logger.info(message, extra=extra)
 
 
 def run_with_coverage():  # pragma: no cover
@@ -188,11 +196,16 @@ def main():  # pragma: no cover
         action='store_true', default=False,
         help='enables coverage when running tests'
     )
+    parser.add_argument(
+        '-o', '--capture-output',
+        action='store_true', default=False,
+        help='capture stdout/stderr output from supervisor processes in addition to events'
+    )
     args = parser.parse_args()
     if args.coverage:
         run_with_coverage()
 
-    application(include=args.include)
+    application(include=args.include, capture_output=args.capture_output)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -110,12 +110,11 @@ def application(include=None, capture_output=False):
     """
     Main application loop.
     """
-    env = os.environ
 
     try:
-        host = env['LOGSTASH_SERVER']
-        port = int(env['LOGSTASH_PORT'])
-        socket_type = env['LOGSTASH_PROTO']
+        host = os.environ['LOGSTASH_SERVER']
+        port = int(os.environ['LOGSTASH_PORT'])
+        socket_type = os.environ['LOGSTASH_PROTO']
     except KeyError:
         sys.exit("LOGSTASH_SERVER, LOGSTASH_PORT and LOGSTASH_PROTO are "
                  "required.")
@@ -124,8 +123,7 @@ def application(include=None, capture_output=False):
     events = ['PROCESS_STATE_' + state for state in events]
 
     if capture_output:
-        outputs = ['STDOUT', 'STDERR']
-        events += ['PROCESS_LOG_' + output for output in outputs]
+        events += ['PROCESS_LOG_STDOUT', 'PROCESS_LOG_STDERR']
 
     logstash_handler = None
     if socket_type == 'udp':
@@ -156,13 +154,13 @@ def application(include=None, capture_output=False):
         # the data is set to '' in event_data(). Stdout/Stderr events
         # do have a message body, so use that if it's present, or fall
         # back to eventname/processname if it's not.
-        message = event_data if len(event_data) \
+        event_data = event_data if len(event_data) \
                              else '%s %s' % (
                                  headers['eventname'],
                                  event_body['processname']
                              )
 
-        logger.info(message, extra=extra)
+        logger.info(event_data, extra=extra)
 
 
 def run_with_coverage():  # pragma: no cover

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """
-Setup script for building
+Setup script for building supervisor-logstash-notifier
 """
 
 from setuptools import setup, find_packages
@@ -23,7 +23,7 @@ with open('requirements.txt') as requirements, \
         open('test_requirements.txt') as test_requirements:
     setup(
         name='supervisor-logstash-notifier',
-        version='0.1.1',
+        version='0.2.0',
         packages=find_packages(),
         url='https://github.com/dohop/supervisor-logstash-notifier',
         license='Apache 2.0',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,3 @@ pylint
 pylint-mccabe
 testfixtures
 nose
-supervisor

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ pylint
 pylint-mccabe
 testfixtures
 nose
+supervisor

--- a/tests/supervisord.template
+++ b/tests/supervisord.template
@@ -21,3 +21,5 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:messages]
 command=./tests/messages
+stdout_events_enabled=true
+stderr_events_enabled=true

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -222,7 +222,10 @@ class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
                 'LOGSTASH_PROTO': 'udp',
                 'COVERAGE_PROCESS_START': '.coveragerc'
             }
-            config = get_config(arguments='--capture-output', events='PROCESS_LOG')
+            config = get_config(
+                        arguments='--capture-output',
+                        events='PROCESS_LOG'
+                     )
             self.run_supervisor(environment, config)
 
             try:

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -223,9 +223,9 @@ class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
                 'COVERAGE_PROCESS_START': '.coveragerc'
             }
             config = get_config(
-                        arguments='--capture-output',
-                        events='PROCESS_LOG'
-                     )
+                arguments='--capture-output',
+                events='PROCESS_LOG'
+            )
             self.run_supervisor(environment, config)
 
             try:

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -205,6 +205,7 @@ class SupervisorKeyvalsLoggingTestCase(BaseSupervisorTestCase):
                 message['user_data']
             )
 
+
 class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
     """
     Test capturing stdout/stderr logs.
@@ -250,6 +251,7 @@ class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
                 self.shutdown_supervisor()
         finally:
             self.shutdown_logstash()
+
 
 class TestIncludeParser(TestCase):
     """

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -164,16 +164,19 @@ def record(eventname, from_state):
     }
 
 
-def get_config(arguments=None):
+def get_config(arguments=None, events=None):
     """
     Retruns a pre-formatted configuration block for supervisor
     """
     if arguments is None:
         arguments = ''
 
+    if events is None:
+        events = 'PROCESS_STATE'
+
     configuration_string = '''
 [eventlistener:logstash-notifier]
 command = ./logstash_notifier/__init__.py --coverage %(arguments)s
-events = PROCESS_STATE
+events = %(events)s
 '''
-    return configuration_string % {'arguments': arguments}
+    return configuration_string % {'arguments': arguments, 'events': events}


### PR DESCRIPTION
Greetings,

the PR below allows for a user to also capture stdout/stderr events and forward those to logstash the same way you enabled process state change events.

To do so, the application must be invoked with an additional switch, namely ```--capture-output```, and none of the current behaviour changes without this switch being provided.

I've added tests & help text as well, but was less confident updating the README in this PR; please let me know if you'd like to do that yourself, have me propose wording or follow your guidance.

Thanks,

P.S. the records would look something like this:

```
{
  "groupname": "logging_test",
  "tags": [],
  "@version": "1",
  "@timestamp": "2016-03-29T00:21:53.789Z",
  "level": "INFO",
  "pid": "8644",
  "eventname": "PROCESS_LOG_STDERR",
  "processname": "logging_test",
  "host": "ip-10-93-130-24",
  "logger_name": "supervisor",
  "path": "/home/bob/sources/git/supervisor-logstash-notifier/logstash_notifier/__init__.py",
  "message": "Tue Mar 29 00:21:53 2016 at -e line 1.\n",
  "type": "logstash",
  "channel": "stderr"
}
{
  "groupname": "logging_test",
  "tags": [],
  "@version": "1",
  "@timestamp": "2016-03-29T00:21:58.789Z",
  "level": "INFO",
  "pid": "8644",
  "eventname": "PROCESS_LOG_STDOUT",
  "processname": "logging_test",
  "host": "ip-10-93-130-24",
  "logger_name": "supervisor",
  "path": "/home/bob/sources/git/supervisor-logstash-notifier/logstash_notifier/__init__.py",
  "message": "Tue Mar 29 00:21:58 2016\n",
  "type": "logstash",
  "channel": "stdout"
}
```