### PR TITLE
Add python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+- '2.6'
 - '2.7'
 - '3.2'
 - '3.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - ./install_supervisor
 - pip install coveralls
 script:
-- .githooks/pre-commit -f
+-  if [ "$TRAVIS_PYTHON_VERSION" != "2.6" ]; then .githooks/pre-commit -f; fi
 - nosetests --with-coverage --cover-erase --cover-tests
 sudo: false
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - ./install_supervisor
 - pip install coveralls
 script:
--  if [ "$TRAVIS_PYTHON_VERSION" != "2.6" ]; then .githooks/pre-commit -f; fi
+- if [ "$TRAVIS_PYTHON_VERSION" != "2.6" ]; then .githooks/pre-commit -f; fi
 - nosetests --with-coverage --cover-erase --cover-tests
 sudo: false
 after_success:

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Logstash instance.
 Installation
 ------------
 
-Python 2.7 or Python 3.2+ is required.
+Python 2.6, 2.7 or Python 3.2+ is required.
 
 ::
 
@@ -68,7 +68,7 @@ shell, you can pass them in via Supervisor's configuration:
 Advanced Usage
 --------------
 
-It is also possible to include environment variables in the event messages, 
+It is also possible to include environment variables in the event messages,
 by specifying the name of the environment variables to include:
 
 ::
@@ -110,7 +110,7 @@ Logstash can be simply configured to receive events:
 
 The JSON produced by the events and log output will look like this:
 
-::    
+::
 
     # State changes
     {
@@ -146,7 +146,7 @@ The JSON produced by the events and log output will look like this:
       "processname": "myprocess",
       "tags": [],
       "type": "logstash",
-    }   
+    }
 
 .. |Build Status| image:: https://travis-ci.org/dohop/supervisor-logstash-notifier.svg?branch=master
    :target: https://travis-ci.org/dohop/supervisor-logstash-notifier

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-logstash==0.4.6
 six==1.10.0
+# needed for python 2.6
+argparse

--- a/setup.py
+++ b/setup.py
@@ -19,24 +19,26 @@ Setup script for building supervisor-logstash-notifier
 
 from setuptools import setup, find_packages
 
-with open('requirements.txt') as requirements, \
-        open('test_requirements.txt') as test_requirements:
-    setup(
-        name='supervisor-logstash-notifier',
-        version='0.2.0',
-        packages=find_packages(),
-        url='https://github.com/dohop/supervisor-logstash-notifier',
-        license='Apache 2.0',
-        author='aodj',
-        author_email='alexander@dohop.com',
-        description='Stream supervisor events to a logstash instance',
-        long_description=open('README.rst').read(),
-        entry_points={
-            'console_scripts': [
-                'logstash_notifier = logstash_notifier:main'
-            ]
-        },
-        install_requires=requirements.read().splitlines(),
-        test_suite='tests',
-        tests_require=test_requirements.read().splitlines(),
-    )
+# 2 step 'with open' to be python2.6 compatible
+with open('requirements.txt') as requirements:
+    with open('test_requirements.txt') as test_requirements:
+
+        setup(
+            name='supervisor-logstash-notifier',
+            version='0.2.0',
+            packages=find_packages(),
+            url='https://github.com/dohop/supervisor-logstash-notifier',
+            license='Apache 2.0',
+            author='aodj',
+            author_email='alexander@dohop.com',
+            description='Stream supervisor events to a logstash instance',
+            long_description=open('README.rst').read(),
+            entry_points={
+                'console_scripts': [
+                    'logstash_notifier = logstash_notifier:main'
+                ]
+            },
+            install_requires=requirements.read().splitlines(),
+            test_suite='tests',
+            tests_require=test_requirements.read().splitlines(),
+        )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as requirements:
 
         setup(
             name='supervisor-logstash-notifier',
-            version='0.2.0',
+            version='0.2.1',
             packages=find_packages(),
             url='https://github.com/dohop/supervisor-logstash-notifier',
             license='Apache 2.0',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,6 @@ pylint
 pylint-mccabe
 testfixtures
 nose
+# needed for python 2.6
+unittest2
+coverage

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -44,18 +44,18 @@ class SupervisorLoggingTestCase(BaseSupervisorTestCase):
             }
 
             config = get_config()
-            self.run_supervisor(environment, config)
+            config_file = self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', 'stop', 'messages'])
+                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STOPPED', 'STOPPING'),
                 ]
                 received = self.messages(clear_buffer=True, wait_for=1)
                 self.assertEqual(received, expected)
 
-                subprocess.call(['supervisorctl', 'start', 'messages'])
+                subprocess.call(['supervisorctl', '-c', config_file,  'start', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STARTING', 'STOPPED'),
                     record('PROCESS_STATE_RUNNING', 'STARTING'),
@@ -64,7 +64,7 @@ class SupervisorLoggingTestCase(BaseSupervisorTestCase):
                 received = self.messages(clear_buffer=True, wait_for=2)
                 self.assertEqual(received, expected)
 
-                subprocess.call(['supervisorctl', 'restart', 'messages'])
+                subprocess.call(['supervisorctl', '-c', config_file,  'restart', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STOPPED', 'STOPPING'),
                     record('PROCESS_STATE_STARTING', 'STOPPED'),
@@ -99,11 +99,11 @@ class SupervisorEnvironmentLoggingTestCase(BaseSupervisorTestCase):
                 environment.update(include)
 
             config = get_config(arguments='--include FRUITS VEGETABLES')
-            self.run_supervisor(environment, config)
+            config_file = self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', 'stop', 'messages'])
+                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
                 received = self.messages(clear_buffer=True, wait_for=1)
                 # should only have the 'stopping' message
                 self.assertTrue(len(received) == 1)
@@ -174,11 +174,11 @@ class SupervisorKeyvalsLoggingTestCase(BaseSupervisorTestCase):
                           'bears="polar,brown,black" '
                           'notbears="unicorn,griffin,sphinx,otter"'
             )
-            self.run_supervisor(environment, config)
+            config_file = self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', 'stop', 'messages'])
+                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
                 received = self.messages(clear_buffer=True, wait_for=1)
                 # should only have the 'stopping' message
                 self.assertTrue(len(received) == 1)
@@ -227,7 +227,7 @@ class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
                 arguments='--capture-output',
                 events='PROCESS_LOG'
             )
-            self.run_supervisor(environment, config)
+            config_file = self.run_supervisor(environment, config)
 
             try:
                 expected = [{

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -18,11 +18,10 @@ Test logstash_notifier
 """
 
 import os
-import subprocess
 
 try:
     from unittest2 import TestCase
-except:
+except ImportError:
     from unittest import TestCase
 
 from .utilities import BaseSupervisorTestCase, record, get_config

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -20,7 +20,10 @@ Test logstash_notifier
 import os
 import subprocess
 
-from unittest import TestCase
+try:
+    from unittest2 import TestCase
+except:
+    from unittest import TestCase
 
 from .utilities import BaseSupervisorTestCase, record, get_config
 from logstash_notifier import get_value_from_input

--- a/tests/test_logstash_notifier.py
+++ b/tests/test_logstash_notifier.py
@@ -44,18 +44,18 @@ class SupervisorLoggingTestCase(BaseSupervisorTestCase):
             }
 
             config = get_config()
-            config_file = self.run_supervisor(environment, config)
+            self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
+                self.run_supervisorctl(['stop', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STOPPED', 'STOPPING'),
                 ]
                 received = self.messages(clear_buffer=True, wait_for=1)
                 self.assertEqual(received, expected)
 
-                subprocess.call(['supervisorctl', '-c', config_file,  'start', 'messages'])
+                self.run_supervisorctl(['start', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STARTING', 'STOPPED'),
                     record('PROCESS_STATE_RUNNING', 'STARTING'),
@@ -64,7 +64,7 @@ class SupervisorLoggingTestCase(BaseSupervisorTestCase):
                 received = self.messages(clear_buffer=True, wait_for=2)
                 self.assertEqual(received, expected)
 
-                subprocess.call(['supervisorctl', '-c', config_file,  'restart', 'messages'])
+                self.run_supervisorctl(['restart', 'messages'])
                 expected = [
                     record('PROCESS_STATE_STOPPED', 'STOPPING'),
                     record('PROCESS_STATE_STARTING', 'STOPPED'),
@@ -99,11 +99,11 @@ class SupervisorEnvironmentLoggingTestCase(BaseSupervisorTestCase):
                 environment.update(include)
 
             config = get_config(arguments='--include FRUITS VEGETABLES')
-            config_file = self.run_supervisor(environment, config)
+            self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
+                self.run_supervisorctl(['stop', 'messages'])
                 received = self.messages(clear_buffer=True, wait_for=1)
                 # should only have the 'stopping' message
                 self.assertTrue(len(received) == 1)
@@ -174,11 +174,11 @@ class SupervisorKeyvalsLoggingTestCase(BaseSupervisorTestCase):
                           'bears="polar,brown,black" '
                           'notbears="unicorn,griffin,sphinx,otter"'
             )
-            config_file = self.run_supervisor(environment, config)
+            self.run_supervisor(environment, config)
             self.messages(clear_buffer=True, wait_for=2)
 
             try:
-                subprocess.call(['supervisorctl', '-c', config_file,  'stop', 'messages'])
+                self.run_supervisorctl(['stop', 'messages'])
                 received = self.messages(clear_buffer=True, wait_for=1)
                 # should only have the 'stopping' message
                 self.assertTrue(len(received) == 1)
@@ -227,7 +227,7 @@ class SupervisorOutPutLoggingTestCase(BaseSupervisorTestCase):
                 arguments='--capture-output',
                 events='PROCESS_LOG'
             )
-            config_file = self.run_supervisor(environment, config)
+            self.run_supervisor(environment, config)
 
             try:
                 expected = [{

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -70,11 +70,14 @@ class BaseSupervisorTestCase(TestCase):
             configuration += configuration_string
             self.scratch.write('supervisor.conf', configuration, 'utf-8')
 
+        config_file_path = self.scratch.getpath('supervisor.conf')
         self.supervisor = subprocess.Popen(
-            ['supervisord', '-c', self.scratch.getpath('supervisor.conf')],
+            ['supervisord', '-c', config_file_path],
             env=environment,
             cwd=os.path.dirname(working_directory),
         )
+
+        return config_file_path
 
     def shutdown_supervisor(self):
         """

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     from unittest import TestCase
 
+
 class LogstashHandler(socketserver.BaseRequestHandler):
     """
     Save received messages.

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -22,15 +22,14 @@ import os
 import subprocess
 import threading
 
-try:
-    from unittest2 import TestCase
-except:
-    from unittest import TestCase
-
 from time import sleep
 from testfixtures import TempDirectory
 from six.moves import socketserver
 
+try:
+    from unittest2 import TestCase
+except ImportError:
+    from unittest import TestCase
 
 class LogstashHandler(socketserver.BaseRequestHandler):
     """

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -48,6 +48,8 @@ class BaseSupervisorTestCase(TestCase):
         super(BaseSupervisorTestCase, self).__init__(*args, **kwargs)
         self.supervisor = None
         self.logstash = None
+        # store, as it's also used by supervisorctl
+        self._config_file_path = None
 
     def setUp(self):
         self.scratch = TempDirectory()
@@ -70,14 +72,14 @@ class BaseSupervisorTestCase(TestCase):
             configuration += configuration_string
             self.scratch.write('supervisor.conf', configuration, 'utf-8')
 
-        config_file_path = self.scratch.getpath('supervisor.conf')
+        # store, as it's also used by supervisorctl
+        self._config_file_path = self.scratch.getpath('supervisor.conf')
+
         self.supervisor = subprocess.Popen(
-            ['supervisord', '-c', config_file_path],
+            ['supervisord', '-c', self._config_file_path],
             env=environment,
             cwd=os.path.dirname(working_directory),
         )
-
-        return config_file_path
 
     def shutdown_supervisor(self):
         """
@@ -88,6 +90,18 @@ class BaseSupervisorTestCase(TestCase):
             # need to wait while the process kills off it's children and exits
             # so that it doesn't block the port
             sleep(1)
+
+    def run_supervisorctl(self, args):
+        """
+        Runs supervisorctl using the test suites config file
+        """
+        command = [
+            'supervisorctl',
+            '-c', self._config_file_path,
+        ]
+        command += args
+
+        return subprocess.call(command)
 
     def run_logstash(self):
         """

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -22,8 +22,12 @@ import os
 import subprocess
 import threading
 
+try:
+    from unittest2 import TestCase
+except:
+    from unittest import TestCase
+
 from time import sleep
-from unittest import TestCase
 from testfixtures import TempDirectory
 from six.moves import socketserver
 


### PR DESCRIPTION
In our environment, there are older nodes around that rely on python 2.6. It turns out that with a few small changes, both syntax & modules used can be made compatible with python 2.6.

In addition, this uncovered a bug in the test suite, where supervisord was using a custom configuration file, but supervisorctl was left to scan the environment for a configuration file. In our environment, it found the system wide one before the test suite specific one.

I cleaned up the test suite so both supervisor processes would explicitly use the same configuration file, and wrapped it away behind a convenience function analogous to ```run_supervisor```