### PR TITLE
Add optional newline at the end of every message sent

### DIFF
--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -125,6 +125,10 @@ def __newline_formatter(func):
         if isinstance(result, str):
             line_ending = "\n"
         elif isinstance(result, bytes):
+            # We are redefining the variable type on purpose since python
+            # broke backwards compatibility between 2 & 3. Pylint will
+            # throw an error on this, so we have to disable the check.
+            # pylint: disable=redefined-variable-type
             line_ending = b"\n"
 
         # Avoid double line endings

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -116,9 +116,21 @@ def __newline_formatter(func):
         """
         result = func(*args, **kwargs)
 
+        # The result may be a string, or bytes. In python 2 they are the
+        # same, but in python 3, they are not. First, check for strings
+        # as that works the same in python 2 and 3, THEN check for bytes,
+        # as that implementation is python 3 specific. If it's neither
+        # (future proofing), we use a regular new line
+        if isinstance(result, str):
+            line_ending = "\n"
+        elif isinstance(result, bytes):
+            line_ending = b"\n"
+        else:
+            line_ending = "\n"
+
         # Avoid double line endings
-        if not result.endswith("\n"):
-            result = result + "\n"
+        if not result.endswith(line_ending):
+            result = result + line_ending
 
         return result
 

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -111,6 +111,9 @@ def __newline_formatter(func):
     Wrap a formatter function so a newline is appended if needed to the output
     """
     def __wrapped_func(*args, **kwargs):
+        """
+        Wrapper function that appends a newline to result of original fucntion
+        """
         result = func(*args, **kwargs)
 
         # Avoid double line endings
@@ -121,6 +124,7 @@ def __newline_formatter(func):
 
     # Return the wrapper
     return __wrapped_func
+
 
 def get_logger(append_newline=False):
     """

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -106,7 +106,23 @@ def get_value_from_input(text):
     return values
 
 
-def get_logger():
+def __newline_formatter(func):
+    """
+    Wrap a formatter function so a newline is appended if needed to the output
+    """
+    def __wrapped_func(*args, **kwargs):
+        result = func(*args, **kwargs)
+
+        # Avoid double line endings
+        if not result.endswith("\n"):
+            result = result + "\n"
+
+        return result
+
+    # Return the wrapper
+    return __wrapped_func
+
+def get_logger(append_newline=False):
     """
     Sets up the logger used to send the supervisor events and messages to
     the logstash server, via the socket type provided, port and host defined
@@ -130,17 +146,27 @@ def get_logger():
         raise RuntimeError('Unknown protocol defined: %r' % socket_type)
 
     logger = logging.getLogger('supervisor')
-    logger.addHandler(logstash_handler(host, port, version=1))
+    handler = logstash_handler(host, port, version=1)
+    logger.addHandler(handler)
     logger.setLevel(logging.INFO)
+
+    # To be able to append newlines to the logger output, we'll need to
+    # wrap the formatter. As we can't predict the formatter class, it's
+    # easier to wrap the format() function, which is part of the logger
+    # spec than it is to override/wrap the formatter class, whose name
+    # is determined by the logstash class.
+    if append_newline:
+        handler.formatter.format = \
+            __newline_formatter(handler.formatter.format)
 
     return logger
 
 
-def application(include=None, capture_output=False):
+def application(include=None, capture_output=False, append_newline=False):
     """
     Main application loop.
     """
-    logger = get_logger()
+    logger = get_logger(append_newline=append_newline)
 
     events = ['BACKOFF', 'FATAL', 'EXITED', 'STOPPED', 'STARTING', 'RUNNING']
     events = ['PROCESS_STATE_' + state for state in events]
@@ -214,11 +240,20 @@ def main():  # pragma: no cover
         help='capture stdout/stderr output from supervisor '
              'processes in addition to events'
     )
+    parser.add_argument(
+        '-n', '--append-newline',
+        action='store_true', default=False,
+        help='ensure all messages sent end with a newline character'
+    )
     args = parser.parse_args()
     if args.coverage:
         run_with_coverage()
 
-    application(include=args.include, capture_output=args.capture_output)
+    application(
+        include=args.include,
+        capture_output=args.capture_output,
+        append_newline=args.append_newline,
+    )
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/logstash_notifier/__init__.py
+++ b/logstash_notifier/__init__.py
@@ -121,12 +121,11 @@ def __newline_formatter(func):
         # as that works the same in python 2 and 3, THEN check for bytes,
         # as that implementation is python 3 specific. If it's neither
         # (future proofing), we use a regular new line
+        line_ending = "\n"
         if isinstance(result, str):
             line_ending = "\n"
         elif isinstance(result, bytes):
             line_ending = b"\n"
-        else:
-            line_ending = "\n"
 
         # Avoid double line endings
         if not result.endswith(line_ending):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as requirements:
 
         setup(
             name='supervisor-logstash-notifier',
-            version='0.2.1',
+            version='0.2.2',
             packages=find_packages(),
             url='https://github.com/dohop/supervisor-logstash-notifier',
             license='Apache 2.0',

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -39,7 +39,10 @@ class LogstashHandler(socketserver.BaseRequestHandler):
     messages = []
 
     def handle(self):
-        self.messages.append(self.request[0].strip().decode())
+        # Avoid strip()'ing the message, as there's an option to append
+        # newlines to the output of the app, which strip() would remove
+        # and thus a test would fail
+        self.messages.append(self.request[0].decode())
 
 
 class BaseSupervisorTestCase(TestCase):
@@ -139,6 +142,12 @@ class BaseSupervisorTestCase(TestCase):
             self.clear_message_buffer()
 
         return parsed_messages
+
+    def get_message_buffer(self):
+        """
+        Returns the raw logstash message buffer
+        """
+        return self.logstash.RequestHandlerClass.messages[:]
 
     def clear_message_buffer(self):
         """


### PR DESCRIPTION
Several systems operate on newline terminated streams to distinguish messages.

To support those, a new optional (and backwards) compatible flag is added: ```--append-newline | -n```.
This ensures that any message, regardless of formatting, will be terminated with a "\n" character.

Tests are added, as well as help/docstrings.

Note, this was the cleanest implementation I could come up with, as the actual formatter is controlled by a class 2 levels away. Alternate implementations are welcome, but the functionality is critical for us in production.


